### PR TITLE
fix typo with :people/by-id state update example

### DIFF
--- a/src/tutorial/untangled_tutorial/G_Mutation.cljs
+++ b/src/tutorial/untangled_tutorial/G_Mutation.cljs
@@ -121,7 +121,7 @@
 
   ```
   (swap! state assoc-in [:people/by-id 7] {:id 7 :person/name \"Andy\"})
-  (swap! state update :people/friends conj [:people/by-id 3])
+  (swap! state update :people/friends conj [:people/by-id 7])
   ```
 
   to result in the following app database state:


### PR DESCRIPTION
Based on the result output, I think the intended :people/by-id vector was `[:people/by-id 7]` instead of `3`.
Guessing this was just a quick copy-pasta oversight from the previous example.
