### PR TITLE
Enabled console print to help in debugging

### DIFF
--- a/src/tutorial/untangled_tutorial/B_UI_Exercises.cljs
+++ b/src/tutorial/untangled_tutorial/B_UI_Exercises.cljs
@@ -4,6 +4,8 @@
             [om.dom :as dom]
             [devcards.core :as dc :refer-macros [defcard defcard-doc]]))
 
+(enable-console-print!)
+
 (defcard-doc
 
   "# UI Exercises


### PR DESCRIPTION
Added `(enable-console-print!)` so that click events such as the input `:onClick (fn [e] (println "TODO ex 3"))` can be instructive as they now print to console.
